### PR TITLE
fix(resume-drill): add resilient resume project extraction status

### DIFF
--- a/backend/api/endpoints/resume.py
+++ b/backend/api/endpoints/resume.py
@@ -14,7 +14,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.deps import get_db
 from database import models
-from database.schemas import ResumeProject, ResumeResource, UploadResumeResponse
+from database.schemas import (
+    ResumeExtractionStatus,
+    ResumeProject,
+    ResumeResource,
+    UploadResumeResponse,
+)
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -113,13 +118,18 @@ def _extract_text(filename: str, content: bytes) -> str:
 
 
 def _resume_to_resource(resume: models.Resume) -> ResumeResource:
+    try:
+        extraction_status = ResumeExtractionStatus(resume.extraction_status)
+    except ValueError:
+        extraction_status = ResumeExtractionStatus.UNKNOWN
+
     return ResumeResource(
         id=str(resume.id),
         user_id=resume.user_id,
         filename=resume.filename,
         content_text=resume.content_text,
         projects=[ResumeProject(**project) for project in (resume.projects_json or [])],
-        extraction_status=resume.extraction_status,
+        extraction_status=extraction_status,
         created_at=resume.created_at or datetime.now(UTC),
         updated_at=resume.updated_at or resume.created_at or datetime.now(UTC),
     )

--- a/backend/api/endpoints/resume.py
+++ b/backend/api/endpoints/resume.py
@@ -1,10 +1,13 @@
+import asyncio
 import io
 import json
+import logging
 import uuid
 from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile, status
-from openai import OpenAI
+from openai import APIConnectionError, APIStatusError, APITimeoutError, OpenAI, RateLimitError
+from pydantic import ValidationError
 from pypdf import PdfReader
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -14,9 +17,12 @@ from database import models
 from database.schemas import ResumeProject, ResumeResource, UploadResumeResponse
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 MAX_RESUME_BYTES = 5 * 1024 * 1024
+MAX_PROJECT_EXTRACTION_ATTEMPTS = 3
 SUPPORTED_EXTENSIONS = {".pdf", ".txt", ".md"}
+RETRYABLE_OPENAI_ERRORS = (APIConnectionError, APITimeoutError, RateLimitError)
 
 PROJECT_EXTRACTION_TEXT_FORMAT = {
     "format": {
@@ -113,6 +119,7 @@ def _resume_to_resource(resume: models.Resume) -> ResumeResource:
         filename=resume.filename,
         content_text=resume.content_text,
         projects=[ResumeProject(**project) for project in (resume.projects_json or [])],
+        extraction_status=resume.extraction_status,
         created_at=resume.created_at or datetime.now(UTC),
         updated_at=resume.updated_at or resume.created_at or datetime.now(UTC),
     )
@@ -133,7 +140,67 @@ def _fallback_projects(text: str) -> list[dict]:
     ]
 
 
-async def _extract_projects_with_ai(
+def _normalize_projects(projects: list[dict]) -> list[dict]:
+    normalized = []
+    for project in projects:
+        normalized.append(
+            ResumeProject(
+                project_id=str(project.get("project_id") or uuid.uuid4()),
+                name=str(project.get("name") or "Resume Experience"),
+                role=str(project.get("role") or ""),
+                tech_stack=[
+                    str(item) for item in (project.get("tech_stack") or []) if str(item).strip()
+                ],
+                summary=str(project.get("summary") or ""),
+                evidence=[
+                    str(item) for item in (project.get("evidence") or []) if str(item).strip()
+                ],
+            ).model_dump()
+        )
+    return normalized
+
+
+def _passes_project_quality_gate(projects: list[dict]) -> bool:
+    if not projects:
+        return False
+
+    for project in projects:
+        name = str(project.get("name") or "").strip()
+        summary = str(project.get("summary") or "").strip()
+        evidence = [
+            str(item).strip() for item in project.get("evidence") or [] if str(item).strip()
+        ]
+        if name and name != "Resume Experience" and (summary or evidence):
+            return True
+
+    return False
+
+
+def _is_retryable_openai_error(exc: Exception) -> bool:
+    if isinstance(exc, RETRYABLE_OPENAI_ERRORS):
+        return True
+    if isinstance(exc, APIStatusError):
+        return exc.status_code >= 500
+    return False
+
+
+def _should_retry_project_extraction(exc: Exception) -> bool:
+    if _is_retryable_openai_error(exc):
+        return True
+    return isinstance(
+        exc,
+        (
+            AttributeError,
+            json.JSONDecodeError,
+            KeyError,
+            TypeError,
+            ValueError,
+            ValidationError,
+        ),
+    )
+
+
+def _call_project_extraction(
     text: str,
     openai_api_key: str,
     openai_model: str,
@@ -161,39 +228,64 @@ Resume:
 {text[:24000]}
 """
 
-    try:
-        response = client.responses.create(
-            model=openai_model,
-            instructions=(
-                "You are a strict resume parser. Extract only evidence-backed project entries "
-                "and return valid structured JSON."
-            ),
-            input=prompt,
-            max_output_tokens=1800,
-            temperature=0.2,
-            text=PROJECT_EXTRACTION_TEXT_FORMAT,
-        )
-        payload = json.loads(response.output_text or "{}")
-        projects = payload.get("projects") or []
-        normalized = []
-        for project in projects:
-            normalized.append(
-                ResumeProject(
-                    project_id=str(project.get("project_id") or uuid.uuid4()),
-                    name=str(project.get("name") or "Resume Experience"),
-                    role=str(project.get("role") or ""),
-                    tech_stack=[
-                        str(item) for item in (project.get("tech_stack") or []) if str(item).strip()
-                    ],
-                    summary=str(project.get("summary") or ""),
-                    evidence=[
-                        str(item) for item in (project.get("evidence") or []) if str(item).strip()
-                    ],
-                ).model_dump()
+    response = client.responses.create(
+        model=openai_model,
+        instructions=(
+            "You are a strict resume parser. Extract only evidence-backed project entries "
+            "and return valid structured JSON."
+        ),
+        input=prompt,
+        max_output_tokens=1800,
+        temperature=0,
+        text=PROJECT_EXTRACTION_TEXT_FORMAT,
+    )
+    payload = json.loads(response.output_text or "{}")
+    projects = payload.get("projects") or []
+    return _normalize_projects(projects)
+
+
+async def _extract_projects_with_ai(
+    text: str,
+    openai_api_key: str,
+    openai_model: str,
+    language: str,
+) -> tuple[list[dict], str]:
+    last_error: Exception | None = None
+
+    for attempt in range(1, MAX_PROJECT_EXTRACTION_ATTEMPTS + 1):
+        try:
+            projects = await asyncio.to_thread(
+                _call_project_extraction,
+                text,
+                openai_api_key,
+                openai_model,
+                language,
             )
-        return normalized or _fallback_projects(text)
-    except Exception:
-        return _fallback_projects(text)
+            if _passes_project_quality_gate(projects):
+                return projects, "ai"
+
+            last_error = ValueError("Project extraction did not meet the quality gate.")
+            logger.warning(
+                "Resume project extraction failed quality gate on attempt %s/%s",
+                attempt,
+                MAX_PROJECT_EXTRACTION_ATTEMPTS,
+            )
+        except Exception as exc:
+            last_error = exc
+            logger.warning(
+                "Resume project extraction failed on attempt %s/%s: %s",
+                attempt,
+                MAX_PROJECT_EXTRACTION_ATTEMPTS,
+                exc,
+            )
+            if not _should_retry_project_extraction(exc):
+                break
+
+        if attempt < MAX_PROJECT_EXTRACTION_ATTEMPTS:
+            await asyncio.sleep(0.5 * (2 ** (attempt - 1)))
+
+    logger.warning("Falling back to heuristic resume project extraction: %s", last_error)
+    return _fallback_projects(text), "fallback"
 
 
 @router.get("/current", response_model=ResumeResource | None)
@@ -229,7 +321,9 @@ async def upload_resume(
         )
 
     text = _extract_text(filename, content)
-    projects = await _extract_projects_with_ai(text, openai_api_key, openai_model, language)
+    projects, extraction_status = await _extract_projects_with_ai(
+        text, openai_api_key, openai_model, language
+    )
 
     await db.execute(delete(models.Resume).where(models.Resume.user_id == user_id))
     resume = models.Resume(
@@ -237,6 +331,7 @@ async def upload_resume(
         filename=filename,
         content_text=text,
         projects_json=projects,
+        extraction_status=extraction_status,
     )
     db.add(resume)
     await db.commit()
@@ -244,7 +339,11 @@ async def upload_resume(
 
     return UploadResumeResponse(
         resume=_resume_to_resource(resume),
-        message="Resume uploaded and parsed.",
+        message=(
+            "Resume uploaded and parsed."
+            if extraction_status == "ai"
+            else "Resume uploaded, but project extraction used a fallback parser."
+        ),
     )
 
 

--- a/backend/database/models.py
+++ b/backend/database/models.py
@@ -128,6 +128,7 @@ class Resume(Base):
     filename: Mapped[str] = mapped_column(String(255), nullable=False)
     content_text: Mapped[str] = mapped_column(Text, nullable=False)
     projects_json: Mapped[list[dict]] = mapped_column(JSON, default=lambda: [])
+    extraction_status: Mapped[str] = mapped_column(String(20), default="unknown", nullable=False)
     created_at: Mapped[datetime] = mapped_column(default=datetime.now(UTC))
     updated_at: Mapped[datetime] = mapped_column(
         default=datetime.now(UTC), onupdate=datetime.now(UTC)

--- a/backend/database/schemas.py
+++ b/backend/database/schemas.py
@@ -176,6 +176,7 @@ class ResumeResource(BaseModel):
     filename: str
     content_text: str
     projects: list[ResumeProject]
+    extraction_status: str = "unknown"
     created_at: datetime
     updated_at: datetime
 

--- a/backend/database/schemas.py
+++ b/backend/database/schemas.py
@@ -31,6 +31,12 @@ class SessionType(str, Enum):
     RESUME_DRILL = "resume_drill"
 
 
+class ResumeExtractionStatus(str, Enum):
+    AI = "ai"
+    FALLBACK = "fallback"
+    UNKNOWN = "unknown"
+
+
 class QuestionType(str, Enum):
     OPINION = "opinion"
     TECHNICAL = "technical"
@@ -176,7 +182,7 @@ class ResumeResource(BaseModel):
     filename: str
     content_text: str
     projects: list[ResumeProject]
-    extraction_status: str = "unknown"
+    extraction_status: ResumeExtractionStatus = ResumeExtractionStatus.UNKNOWN
     created_at: datetime
     updated_at: datetime
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -23,6 +23,7 @@ async def lifespan(app: FastAPI):
         for col_sql in [
             "ALTER TABLE questions ADD COLUMN status VARCHAR(20) DEFAULT 'completed'",
             "ALTER TABLE questions ADD COLUMN session_id VARCHAR REFERENCES interview_sessions(id)",
+            "ALTER TABLE resumes ADD COLUMN extraction_status VARCHAR(20) DEFAULT 'unknown' NOT NULL",
         ]:
             try:
                 await conn.execute(text(col_sql))

--- a/frontend/src/components/resume-drill/ResumeDrillSidebar.tsx
+++ b/frontend/src/components/resume-drill/ResumeDrillSidebar.tsx
@@ -31,6 +31,12 @@ function extractionStatusLabel(status: ResumeResource["extraction_status"]) {
   return "Parser status unknown";
 }
 
+function extractionStatusColor(status: ResumeResource["extraction_status"]) {
+  if (status === "ai") return "success";
+  if (status === "fallback") return "warning";
+  return "neutral";
+}
+
 interface ResumeDrillSidebarProps {
   resume: ResumeResource | null;
   projects: ResumeProject[];
@@ -131,7 +137,7 @@ export default function ResumeDrillSidebar({
                       <Chip
                         size="sm"
                         variant="soft"
-                        color={resume.extraction_status === "fallback" ? "warning" : "success"}
+                        color={extractionStatusColor(resume.extraction_status)}
                       >
                         {extractionStatusLabel(resume.extraction_status)}
                       </Chip>

--- a/frontend/src/components/resume-drill/ResumeDrillSidebar.tsx
+++ b/frontend/src/components/resume-drill/ResumeDrillSidebar.tsx
@@ -4,6 +4,7 @@ import {
   Button,
   Card,
   CardContent,
+  Chip,
   Divider,
   IconButton,
   Option,
@@ -23,6 +24,12 @@ import type { ResumeProject, ResumeResource } from "../../types/interview";
 
 const DRILL_POINT_OPTIONS = [1, 2, 3, 5];
 const FOLLOW_UP_ROUND_OPTIONS = [1, 2, 3];
+
+function extractionStatusLabel(status: ResumeResource["extraction_status"]) {
+  if (status === "ai") return "AI parsed";
+  if (status === "fallback") return "Fallback parser";
+  return "Parser status unknown";
+}
 
 interface ResumeDrillSidebarProps {
   resume: ResumeResource | null;
@@ -117,9 +124,18 @@ export default function ResumeDrillSidebar({
                     <Typography level="title-sm" noWrap>
                       {resume.filename}
                     </Typography>
-                    <Typography level="body-xs" sx={{ color: "neutral.500" }}>
-                      {resume.projects.length} projects parsed
-                    </Typography>
+                    <Stack direction="row" spacing={0.75} alignItems="center" flexWrap="wrap">
+                      <Typography level="body-xs" sx={{ color: "neutral.500" }}>
+                        {resume.projects.length} projects parsed
+                      </Typography>
+                      <Chip
+                        size="sm"
+                        variant="soft"
+                        color={resume.extraction_status === "fallback" ? "warning" : "success"}
+                      >
+                        {extractionStatusLabel(resume.extraction_status)}
+                      </Chip>
+                    </Stack>
                   </Box>
                 </Stack>
                 <Stack direction="row" spacing={0.5} sx={{ flexShrink: 0 }}>

--- a/frontend/src/types/interview.ts
+++ b/frontend/src/types/interview.ts
@@ -126,6 +126,7 @@ export interface ResumeResource {
   filename: string;
   content_text: string;
   projects: ResumeProject[];
+  extraction_status: "ai" | "fallback" | "unknown";
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
- Added retry handling for resume project extraction with bounded attempts and backoff.
- Introduced a project quality gate before accepting AI extraction results.
- Persisted extraction_status on resumes and returned it through API schemas.
- Displayed resume extraction status in the Resume Drill sidebar.
- Moved synchronous OpenAI project extraction work onto a background thread.